### PR TITLE
Add Zed extension for golars .glr scripting language

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,11 @@ Tree-sitter grammar + Neovim plugin live under
 [`editors/`](editors/). VS Code extension at
 [`editors/vscode-golars`](editors/vscode-golars/).
 
+**Zed**: Install via curl:
+```bash
+curl -fsSL https://raw.githubusercontent.com/Gaurav-Gosain/golars/main/install-zed-extension.sh | bash
+```
+
 ### Model Context Protocol server
 
 <p align="center"><img src="vhs/out/mcp.gif" alt="golars-mcp"></p>
@@ -280,6 +285,7 @@ method-level status table.
 | [`editors/tree-sitter-golars`](editors/tree-sitter-golars/) | `.glr` grammar (Neovim, Helix)                                                                                                                               |
 | [`editors/vscode-golars`](editors/vscode-golars/)           | VS Code extension (grammar + LSP client)                                                                                                                     |
 | [`editors/nvim-golars`](editors/nvim-golars/)               | Neovim plugin                                                                                                                                                |
+| [`editors/zed-golars`](editors/zed-golars/)                 | Zed extension (grammar + LSP client)                                                                                                                         |
 | [`docs-site/`](docs-site/)                                  | Fumadocs-based website, ships `/llms.txt`, `/llms-full.txt`, and `/docs-md/<slug>` raw-markdown routes for LLM ingestion                                     |
 
 ## Documentation

--- a/editors/zed-golars/.gitignore
+++ b/editors/zed-golars/.gitignore
@@ -1,0 +1,12 @@
+# Rust build artifacts
+/target/
+/Cargo.lock
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# OS
+.DS_Store

--- a/editors/zed-golars/Cargo.toml
+++ b/editors/zed-golars/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "zed_golars"
+version = "0.1.0"
+edition = "2021"
+publish = false
+license = "MIT"
+
+[lib]
+path = "src/lib.rs"
+crate-type = ["cdylib"]
+
+[dependencies]
+zed_extension_api = "0.2.0"

--- a/editors/zed-golars/LICENSE
+++ b/editors/zed-golars/LICENSE
@@ -1,0 +1,25 @@
+MIT License
+
+Copyright (c) 2026 Gaurav Gosain
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+This project is an independent reimplementation of the polars DataFrame library
+in Go. It is not a derivative work of polars' Rust source code. polars is
+distributed under the MIT License; see https://github.com/pola-rs/polars.

--- a/editors/zed-golars/README.md
+++ b/editors/zed-golars/README.md
@@ -19,7 +19,15 @@ Install the language server binary:
 go install github.com/Gaurav-Gosain/golars/cmd/golars-lsp@latest
 ```
 
-### Dev Extension (for testing)
+### Quick Install (One-liner)
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/Gaurav-Gosain/golars/main/install-zed-extension.sh | bash
+```
+
+This clones the extension directly to Zed's extensions directory. Restart Zed to activate.
+
+### Dev Extension (for local development)
 
 1. Open Zed
 2. Go to Extensions → Install Dev Extension

--- a/editors/zed-golars/README.md
+++ b/editors/zed-golars/README.md
@@ -1,0 +1,82 @@
+# Zed Extension for golars
+
+Syntax highlighting, LSP client, and editor features for the golars `.glr` scripting language.
+
+## Features
+
+- **Syntax Highlighting**: Full tree-sitter grammar support for the `.glr` scripting language
+- **LSP Client**: Connects to `golars-lsp` for completions, diagnostics, hover, and more
+- **Language Server**: Uses `stdio` transport to communicate with the `golars-lsp` binary
+- **Editor Features**: Comment toggling, bracket matching, code outline
+
+## Installation
+
+### Prerequisites
+
+Install the language server binary:
+
+```bash
+go install github.com/Gaurav-Gosain/golars/cmd/golars-lsp@latest
+```
+
+### Dev Extension (for testing)
+
+1. Open Zed
+2. Go to Extensions → Install Dev Extension
+3. Select `editors/zed-golars/` from this repository
+
+### From Zed Extension Registry
+
+(Coming soon - pending PR to zed-industries/extensions)
+
+## Configuration
+
+You can configure a custom path to the `golars-lsp` binary in your Zed settings:
+
+```json
+{
+  "lsp": {
+    "golars-lsp": {
+      "binary": {
+        "path": "/path/to/golars-lsp"
+      }
+    }
+  }
+}
+```
+
+## File Structure
+
+```
+zed-golars/
+├── extension.toml          # Extension manifest
+├── Cargo.toml              # Rust crate for LSP WASM extension
+├── src/
+│   └── lib.rs              # LSP client implementation
+├── languages/
+│   └── golars/
+│       ├── config.toml     # Language configuration
+│       ├── highlights.scm  # Syntax highlighting queries
+│       ├── brackets.scm    # Bracket matching
+│       ├── indents.scm     # Indentation rules
+│       ├── outline.scm     # Code outline
+│       └── injections.scm  # Language injection rules
+└── LICENSE                 # MIT License
+```
+
+## Development
+
+To build the extension:
+
+```bash
+cd editors/zed-golars
+cargo build --target wasm32-wasip1 --release
+```
+
+## Grammar Source
+
+The tree-sitter grammar lives at [nkapila6/tree-sitter-golars](https://github.com/nkapila6/tree-sitter-golars).
+
+## License
+
+MIT - see LICENSE file

--- a/editors/zed-golars/extension.toml
+++ b/editors/zed-golars/extension.toml
@@ -1,0 +1,15 @@
+id = "golars"
+name = "golars"
+description = "golars .glr scripting language support: syntax highlighting, LSP, and editor features."
+version = "0.1.0"
+schema_version = 1
+authors = ["Gaurav Gosain <itsgauravgosain@gmail.com>"]
+repository = "https://github.com/Gaurav-Gosain/golars"
+
+[language_servers.golars-lsp]
+name = "golars Language Server"
+languages = ["golars"]
+
+[grammars.golars]
+repository = "https://github.com/nkapila6/tree-sitter-golars"
+commit = "ab6cc9593842cac51a4465a9a0d71f3cafd5afd4"

--- a/editors/zed-golars/languages/golars/brackets.scm
+++ b/editors/zed-golars/languages/golars/brackets.scm
@@ -1,0 +1,3 @@
+("{" @open "}" @close)
+("[" @open "]" @close)
+("(" @open ")" @close)

--- a/editors/zed-golars/languages/golars/config.toml
+++ b/editors/zed-golars/languages/golars/config.toml
@@ -1,0 +1,16 @@
+name = "golars"
+grammar = "golars"
+path_suffixes = ["glr"]
+line_comments = ["# "]
+autoclose_before = ";:.,=}])\">"
+tab_size = 2
+hard_tabs = false
+
+brackets = [
+    { start = "{", end = "}", close = true, newline = true },
+    { start = "[", end = "]", close = true, newline = true },
+    { start = "(", end = ")", close = true, newline = true },
+    { start = "\"", end = "\"", close = true, newline = false, not_in = ["string", "comment"] },
+]
+
+word_characters = ["/", "-", "."]

--- a/editors/zed-golars/languages/golars/highlights.scm
+++ b/editors/zed-golars/languages/golars/highlights.scm
@@ -1,0 +1,29 @@
+; Tree-sitter highlight queries for golars .glr
+;
+; Capture names follow the Zed convention.
+
+; Comments
+(comment) @comment
+
+; Commands: one distinct highlight so the pipeline-opening verb stands out.
+(command) @function.builtin
+
+; Structural keywords: `as`, `on`, `asc`, `desc`, `and`, `or`, join types.
+(keyword) @keyword
+
+; Comparison operators in filter predicates.
+(operator) @operator
+
+; Literals.
+(string) @string
+(number) @number
+(boolean) @constant.builtin
+
+; col:op[:alias] aggregation spec. Highlight as a single unit.
+(agg_spec) @attribute
+
+; Bare identifiers for column names / paths / user-defined commands.
+(identifier) @variable
+
+; The leading '.' on REPL-style commands.
+(statement "." @punctuation.special)

--- a/editors/zed-golars/languages/golars/indents.scm
+++ b/editors/zed-golars/languages/golars/indents.scm
@@ -1,0 +1,3 @@
+; Minimal indentation rules for golars .glr
+; The language is line-oriented with no block structure.
+(source_file) @indent

--- a/editors/zed-golars/languages/golars/injections.scm
+++ b/editors/zed-golars/languages/golars/injections.scm
@@ -1,0 +1,7 @@
+; Tree-sitter injection queries for golars .glr
+;
+; No nested languages to inject for now. The filter predicate DSL is
+; simple enough that a dedicated grammar would just duplicate the
+; token rules from grammar.js. Leave this file in place so editors
+; that expect it don't warn; add actual injections later if we grow
+; an SQL-in-filter feature or similar.

--- a/editors/zed-golars/languages/golars/outline.scm
+++ b/editors/zed-golars/languages/golars/outline.scm
@@ -1,0 +1,3 @@
+; Outline for golars .glr - shows command names in the outline panel
+(statement
+  command: (command) @name) @item

--- a/editors/zed-golars/src/lib.rs
+++ b/editors/zed-golars/src/lib.rs
@@ -1,0 +1,67 @@
+use zed::settings::LspSettings;
+use zed_extension_api::{self as zed, LanguageServerId, Result};
+
+struct GolarsExtension;
+
+impl GolarsExtension {
+    fn language_server_binary_path(
+        &mut self,
+        _language_server_id: &LanguageServerId,
+        worktree: &zed::Worktree,
+    ) -> Result<String> {
+        // Check for user-defined path in settings first
+        if let Some(path) = LspSettings::for_worktree("golars-lsp", worktree)
+            .ok()
+            .and_then(|s| s.binary)
+            .and_then(|b| b.path)
+        {
+            return Ok(path);
+        }
+
+        // Check if golars-lsp is available on PATH
+        if let Some(path) = worktree.which("golars-lsp") {
+            return Ok(path);
+        }
+
+        // Not found - return helpful error message
+        Err("golars-lsp not found on PATH.
+
+Install with:
+    go install github.com/Gaurav-Gosain/golars/cmd/golars-lsp@latest
+
+Or configure a custom path in Zed settings:
+    \"lsp\": {
+        \"golars-lsp\": {
+            \"binary\": { \"path\": \"/path/to/golars-lsp\" }
+        }
+    }".into())
+    }
+}
+
+impl zed::Extension for GolarsExtension {
+    fn new() -> Self {
+        Self
+    }
+
+    fn language_server_command(
+        &mut self,
+        language_server_id: &LanguageServerId,
+        worktree: &zed::Worktree,
+    ) -> Result<zed::Command> {
+        Ok(zed::Command {
+            command: self.language_server_binary_path(language_server_id, worktree)?,
+            args: vec![],
+            env: Default::default(),
+        })
+    }
+
+    fn language_server_workspace_configuration(
+        &mut self,
+        _language_server_id: &LanguageServerId,
+        _worktree: &zed::Worktree,
+    ) -> Result<Option<zed::serde_json::Value>> {
+        Ok(None)
+    }
+}
+
+zed::register_extension!(GolarsExtension);

--- a/install-zed-extension.sh
+++ b/install-zed-extension.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+# Install script for golars Zed extension
+# Usage: curl -fsSL https://raw.githubusercontent.com/Gaurav-Gosain/golars/main/install-zed-extension.sh | bash
+
+set -e
+
+REPO_URL="https://github.com/Gaurav-Gosain/golars.git"
+EXTENSION_DIR="editors/zed-golars"
+
+# Detect platform and set extensions directory
+detect_extensions_dir() {
+    case "$(uname -s)" in
+        Darwin)
+            # macOS
+            echo "$HOME/Library/Application Support/Zed/extensions"
+            ;;
+        Linux)
+            # Try XDG_CONFIG_HOME first, then default
+            if [ -n "$XDG_CONFIG_HOME" ]; then
+                echo "$XDG_CONFIG_HOME/zed/extensions"
+            else
+                echo "$HOME/.config/zed/extensions"
+            fi
+            ;;
+        CYGWIN*|MINGW32*|MSYS*|MINGW*)
+            # Windows
+            if [ -n "$LOCALAPPDATA" ]; then
+                echo "$LOCALAPPDATA/Zed/extensions"
+            else
+                echo "$HOME/AppData/Local/Zed/extensions"
+            fi
+            ;;
+        *)
+            echo "Unsupported platform: $(uname -s)" >&2
+            exit 1
+            ;;
+    esac
+}
+
+EXTENSIONS_DIR=$(detect_extensions_dir)
+INSTALL_DIR="$EXTENSIONS_DIR/golars"
+
+echo "Installing golars Zed extension..."
+echo "Platform: $(uname -s)"
+echo "Extensions directory: $EXTENSIONS_DIR"
+
+# Create extensions directory if it doesn't exist
+mkdir -p "$EXTENSIONS_DIR"
+
+# Remove existing installation if present
+if [ -d "$INSTALL_DIR" ]; then
+    echo "Removing existing installation..."
+    rm -rf "$INSTALL_DIR"
+fi
+
+# Clone the extension
+echo "Cloning extension from $REPO_URL..."
+git clone --depth 1 --filter=blob:none --sparse "$REPO_URL" "$INSTALL_DIR"
+
+# Sparse checkout only the extension directory
+cd "$INSTALL_DIR"
+git sparse-checkout set "$EXTENSION_DIR"
+
+# Move extension files to root of install directory
+mv "$EXTENSION_DIR"/* .
+rm -rf "$EXTENSION_DIR"
+
+echo ""
+echo "golars Zed extension installed successfully!"
+echo ""
+echo "Next steps:"
+echo "  1. Install the LSP binary: go install github.com/Gaurav-Gosain/golars/cmd/golars-lsp@latest"
+echo "  2. Restart Zed or reload extensions"
+echo "  3. Open any .glr file to use the extension"
+echo ""
+echo "Installation location: $INSTALL_DIR"


### PR DESCRIPTION
This adds a complete Zed extension with:
- Syntax highlighting via tree-sitter grammar
- LSP client for golars-lsp (stdio transport)
- Language configuration (.glr extension, # comments, brackets)
- Highlight queries, brackets, indents, outline, and injections

The extension is located in editors/zed-golars/ and includes
all necessary files for submission to the Zed extension registry.