### PR TITLE
feat(ci): adds issue claim workflow via comments

### DIFF
--- a/.github/workflows/assign-issue.yml
+++ b/.github/workflows/assign-issue.yml
@@ -1,0 +1,73 @@
+name: Handle Issue Claims
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions: read-all
+
+jobs:
+  handle-issue:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+
+    steps:
+      - name: Process issue commands
+        uses: actions/github-script@v8
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const issue   = context.payload.issue;
+            const comment = context.payload.comment.body.trim();
+            const user    = context.payload.comment.user.login;
+
+            // Ignore comments on pull requests
+            if (issue.pull_request) {
+              console.log("Comment is on a PR, ignoring.");
+              return;
+            }
+
+            // Handle `.take`
+            if (comment === ".take") {
+              if (issue.assignees?.length) {
+                const currentAssignee = issue.assignees[0].login;
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  body: `@${user} this issue is already assigned to a contributor.`
+                });
+
+                console.log(`Issue #${issue.number} already assigned to ${currentAssignee}, ignoring .take from ${user}`);
+                return;
+              }
+
+              await github.rest.issues.addAssignees({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                assignees: [user]
+              });
+
+              console.log(`${user} assigned to issue #${issue.number}`);
+            }
+
+            // Handle `.release`
+            if (comment === ".release") {
+              const isAssignee = issue.assignees.some(a => a.login === user);
+
+              if (!isAssignee) {
+                console.log(`${user} is not an assignee, ignoring.`);
+                return;
+              }
+
+              await github.rest.issues.removeAssignees({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                assignees: [user]
+              });
+
+              console.log(`${user} released issue #${issue.number}`);
+            }

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
   <a href="https://github.com/Gaurav-Gosain/golars/releases"><img src="https://img.shields.io/github/release/Gaurav-Gosain/golars.svg" alt="Latest Release"></a>
   <a href="https://pkg.go.dev/github.com/Gaurav-Gosain/golars?tab=doc"><img src="https://godoc.org/github.com/Gaurav-Gosain/golars?status.svg" alt="GoDoc"></a>
   <a href="https://github.com/Gaurav-Gosain/golars/actions/workflows/ci.yml"><img src="https://github.com/Gaurav-Gosain/golars/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
+  <a href="https://deepwiki.com/Gaurav-Gosain/golars"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki"></a>
   <br>
   <br>
   <em>Pure-Go DataFrames modeled on polars, built on Apache Arrow. No cgo.</em>


### PR DESCRIPTION
Introduce a GitHub Actions workflow to manage issue assignment using comment commands.

Supports `.take` to assign the commenter if the issue is unassigned, and `.release` to remove themselves as assignee.

Ignores pull request comments and prevents claiming already-assigned issues.